### PR TITLE
Redirect to use correct context

### DIFF
--- a/iwana-extract/src/main/java/com/evernote/iwana/extract/ContextBase.java
+++ b/iwana-extract/src/main/java/com/evernote/iwana/extract/ContextBase.java
@@ -34,6 +34,15 @@ import com.evernote.iwana.pb.TSWP.TSWPArchives.PlaceholderSmartFieldArchive;
 import com.evernote.iwana.pb.TSWP.TSWPArchives.StorageArchive;
 import com.google.protobuf.Message;
 
+import com.evernote.iwana.pb.TSCE.TSCEArchives.ASTNodeArrayArchive.ASTNodeArchive;
+import com.evernote.iwana.pb.TSD.TSDArchives.CommentStorageArchive;
+import com.evernote.iwana.pb.TSK.TSKArchives.DocumentArchive;
+import com.evernote.iwana.pb.TST.TSTArchives.TableDataList;
+import com.evernote.iwana.pb.TST.TSTArchives.TableDataList.ListEntry;
+import com.evernote.iwana.pb.TST.TSTArchives.TableDataList.ListType;
+
+
+
 /**
  * Defines common actions for message types that are relevant to text extraction.
  * 
@@ -153,6 +162,31 @@ class ContextBase extends ExtractTextIWAContext {
         });
 
     COMMON_ACTIONS.setAction(3008, new StoreObject<GroupArchive>(GroupArchive.PARSER));
+    
+    COMMON_ACTIONS.setAction(200, new ExtractTextActionBase<DocumentArchive>(DocumentArchive.PARSER) {
+    	@Override
+    	protected void onMessage(DocumentArchive message, ArchiveInfo ai, MessageInfo mi, ExtractTextIWAContext context) throws IOException {
+            message.getActivityLogEntriesCount();
+            ((ExtractTextCallback)context.getTarget()).onMetaBlock("ActivityLogCount", String.valueOf(message.getActivityLogEntriesCount()));
+        }
+    });
+    COMMON_ACTIONS.setAction(600, new ExtractTextActionBase<com.evernote.iwana.pb.TSA.TSAArchives.DocumentArchive>(com.evernote.iwana.pb.TSA.TSAArchives.DocumentArchive.PARSER) {
+    	@Override
+    	protected void onMessage(com.evernote.iwana.pb.TSA.TSAArchives.DocumentArchive message, ArchiveInfo ai, MessageInfo mi, ExtractTextIWAContext context) throws IOException {
+            message.getDocumentLanguage();
+            message.getNeedsMovieCompatibilityUpgrade();
+            message.getSerializedSize();
+            ((ExtractTextCallback)context.getTarget()).onMetaBlock("NeedsMovieCompatibilityUpgrade", String.valueOf(message.getNeedsMovieCompatibilityUpgrade()));
+        }
+    });
+    COMMON_ACTIONS.setAction(3056, new ExtractTextActionBase<CommentStorageArchive>(CommentStorageArchive.PARSER) {
+    	@Override
+        protected void onMessage(CommentStorageArchive message, ArchiveInfo ai, MessageInfo mi, ExtractTextIWAContext context) throws IOException {
+            message.toString();
+            ((ExtractTextCallback)context.getTarget()).onMetaBlock("hasCommentsOrAnnotations", "true");
+            ((ExtractTextCallback)context.getTarget()).onMetaBlock("Comments", message.getText());
+        }
+    });
   }
 
   @Override

--- a/iwana-extract/src/main/java/com/evernote/iwana/extract/ExtractTextApp.java
+++ b/iwana-extract/src/main/java/com/evernote/iwana/extract/ExtractTextApp.java
@@ -17,28 +17,43 @@ package com.evernote.iwana.extract;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * A demo application.
+ * A demo application. Returns text and metadata from the document in a map.
  */
 public class ExtractTextApp {
-  public static void main(String[] args) throws IOException {
-    if (args.length != 1) {
-      System.err.println("Syntax: ExtractTextApp <filename>");
-      System.exit(1);
+	private String texts = "";
+    private Map<String, String> metaDatas = new HashMap();
+
+    public ExtractTextApp() {
     }
-
-    ExtractTextCallback target = new ExtractTextCallback() {
-
-      @Override
-      public void onTextBlock(String text, TextAttributes scope) {
-        System.out.println(text);
-        System.out.println();
-      }
-
-    };
-
-    ExtractTextIWAParser parser = new ExtractTextIWAParser();
-    parser.parse(new File(args[0]), target);
-  }
+    public Map<String, String> parse(String[] args) throws IOException {
+        this.texts = "";
+        this.metaDatas = new HashMap();
+        if (args.length != 1) {
+            System.err.println("Syntax: ExtractTextApp <filename>");
+            System.exit(1);
+        }
+        ExtractTextCallback target = new ExtractTextCallback() {
+            public void onTextBlock(String text, TextAttributes scope) {
+                ExtractTextApp.this.texts = ExtractTextApp.this.texts + "  " + text;
+            }
+            public void onMetaBlock(String key, String value) {
+                String prev = "";
+                if (!ExtractTextApp.this.metaDatas.containsKey(key)) {
+                    ExtractTextApp.this.metaDatas.put(key, value);
+                } else if (key == "Comments") {
+                    prev = (String)ExtractTextApp.this.metaDatas.get(key);
+                    ExtractTextApp.this.metaDatas.remove(key);
+                    ExtractTextApp.this.metaDatas.put(key, prev + "; " + value);
+                }
+            }
+        };
+        ExtractTextIWAParser parser = new ExtractTextIWAParser();
+        parser.parse(new File(args[0]), target, args[0]);
+        this.metaDatas.put("text", this.texts);
+        return this.metaDatas;
+    }      
 }

--- a/iwana-extract/src/main/java/com/evernote/iwana/extract/ExtractTextCallback.java
+++ b/iwana-extract/src/main/java/com/evernote/iwana/extract/ExtractTextCallback.java
@@ -29,4 +29,7 @@ public abstract class ExtractTextCallback extends IwanaParserCallback {
    * @param attrs Some text attributes
    */
   public abstract void onTextBlock(final String text, TextAttributes attrs);
+  
+  public abstract void onMetaBlock(String feild, String value);
+
 }

--- a/iwana-extract/src/main/java/com/evernote/iwana/extract/ExtractTextIWAContext.java
+++ b/iwana-extract/src/main/java/com/evernote/iwana/extract/ExtractTextIWAContext.java
@@ -128,8 +128,8 @@ public abstract class ExtractTextIWAContext extends IwanaContext<ExtractTextCall
 
   @Override
   public void onEndParseIndexZip() {
-    // Remove placeholder text
-    removePlaceholderText();
+    // Remove placeholder text; ignoring - not working as expected, replacing most of the text.
+    //removePlaceholderText();
 
     // Order content
     Message obj = objectStorage.get(1L);

--- a/iwana-extract/src/main/java/com/evernote/iwana/extract/ExtractTextIWAParser.java
+++ b/iwana-extract/src/main/java/com/evernote/iwana/extract/ExtractTextIWAParser.java
@@ -25,20 +25,19 @@ class ExtractTextIWAParser extends IwanaParser<ExtractTextCallback> {
   @Override
   protected ExtractTextIWAContext newContext(String documentName,
       ExtractTextCallback target) {
-    //FIXME -- the original document name is not actually
-    //passed into this by the IWAParser.  So, for now,
-    //this is misleading because the ContextBase is always returned
-    if (documentName == null) {
-      return new ContextBase(documentName, target);
-    }
-    if (documentName.endsWith(".key")) {
-      return new KeynoteContext(documentName, target);
-    } else if (documentName.endsWith(".pages")) {
-      return new PagesContext(documentName, target);
-    } else if (documentName.endsWith(".numbers")) {
-      return new NumbersContext(documentName, target);
-    } else {
-      return new ContextBase(documentName, target);
-    }
+	  if (documentName == null) {
+          return new ContextBase(documentName, target);
+      } else if (documentName.endsWith(".key")) {
+          target.onMetaBlock("Content-Type", "application/vnd.apple.keynote");
+          return new KeynoteContext(documentName, target);
+      } else if (documentName.endsWith(".pages")) {
+          target.onMetaBlock("Content-Type", "application/vnd.apple.pages");
+          return new PagesContext(documentName, target);
+      } else if (documentName.endsWith(".numbers")) {
+          target.onMetaBlock("Content-Type", "application/vnd.apple.numbers");
+          return new NumbersContext(documentName, target);
+      } else {
+          return new ContextBase(documentName, target);
+      }
   }
 }

--- a/iwana-extract/src/main/java/com/evernote/iwana/extract/KeynoteContext.java
+++ b/iwana-extract/src/main/java/com/evernote/iwana/extract/KeynoteContext.java
@@ -15,6 +15,7 @@
  */
 package com.evernote.iwana.extract;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,6 +37,8 @@ import com.evernote.iwana.pb.TSD.TSDArchives.DrawableArchive;
 import com.evernote.iwana.pb.TSD.TSDArchives.ShapeArchive;
 import com.evernote.iwana.pb.TSP.TSPMessages.Reference;
 import com.evernote.iwana.pb.TSWP.TSWPArchives.ShapeInfoArchive;
+import com.evernote.iwana.pb.TSP.TSPArchiveMessages.ArchiveInfo;
+import com.evernote.iwana.pb.TSP.TSPArchiveMessages.MessageInfo;
 import com.google.protobuf.Message;
 
 /**
@@ -47,8 +50,15 @@ class KeynoteContext extends ContextBase {
   private static final MessageActions KEYNOTE_ACTIONS = new MessageActions(
       ContextBase.COMMON_ACTIONS);
   static {
-    KEYNOTE_ACTIONS
-        .setAction(1, new StoreObject<DocumentArchive>(DocumentArchive.PARSER));
+	KEYNOTE_ACTIONS.setAction(1, new ExtractTextActionBase<DocumentArchive>(DocumentArchive.PARSER) {
+			@Override
+			protected void onMessage(DocumentArchive message, ArchiveInfo ai, MessageInfo mi, ExtractTextIWAContext context)
+					throws IOException {
+				((ExtractTextCallback)context.getTarget()).onMetaBlock("PreventImageConversionOnOpenning", String.valueOf(message.getSuper().getSuper().getPreventImageConversionOnOpen()));
+	            ((ExtractTextCallback)context.getTarget()).onMetaBlock("getNeedsMovieCompatibilityUpgrade", String.valueOf(message.getSuper().getNeedsMovieCompatibilityUpgrade()));
+
+			}
+	    });
     KEYNOTE_ACTIONS.setAction(2, new StoreObject<ShowArchive>(ShowArchive.PARSER));
     KEYNOTE_ACTIONS.setAction(4, new StoreObject<SlideNodeArchive>(
         SlideNodeArchive.PARSER));

--- a/iwana-extract/src/main/java/com/evernote/iwana/extract/NumbersContext.java
+++ b/iwana-extract/src/main/java/com/evernote/iwana/extract/NumbersContext.java
@@ -38,8 +38,15 @@ class NumbersContext extends ContextBase {
       ContextBase.COMMON_ACTIONS);
 
   static {
-    NUMBERS_ACTIONS
-        .setAction(1, new StoreObject<DocumentArchive>(DocumentArchive.PARSER));
+    NUMBERS_ACTIONS.setAction(1, new ExtractTextActionBase<DocumentArchive>(DocumentArchive.PARSER) {
+	    	@Override
+	        protected void onMessage(DocumentArchive message, ArchiveInfo ai, MessageInfo mi, ExtractTextIWAContext context) throws IOException {
+	            ((ExtractTextCallback)context.getTarget()).onMetaBlock("PreventImageConversionOnOpenning", String.valueOf(message.getSuper().getSuper().getPreventImageConversionOnOpen()));
+	            ((ExtractTextCallback)context.getTarget()).onMetaBlock("getNeedsMovieCompatibilityUpgrade", String.valueOf(message.getSuper().getNeedsMovieCompatibilityUpgrade()));
+	            ((ExtractTextCallback)context.getTarget()).onMetaBlock("PageSize", String.valueOf(message.getPageSize()));
+	            ((ExtractTextCallback)context.getTarget()).onMetaBlock("NumberOfSheets", String.valueOf(message.getSheetsCount()));
+	        }
+	    });
 
     NUMBERS_ACTIONS.setAction(new int[] {6005, 6201}, new StoreObject<TableDataList>(
         TableDataList.PARSER) {

--- a/iwana-extract/src/main/java/com/evernote/iwana/extract/PagesContext.java
+++ b/iwana-extract/src/main/java/com/evernote/iwana/extract/PagesContext.java
@@ -15,14 +15,38 @@
  */
 package com.evernote.iwana.extract;
 
+import java.io.IOException;
 import com.evernote.iwana.MessageActions;
+import com.evernote.iwana.pb.TP.TPArchives.DocumentArchive;
+import com.evernote.iwana.pb.TSP.TSPArchiveMessages.ArchiveInfo;
+import com.evernote.iwana.pb.TSP.TSPArchiveMessages.MessageInfo;
 
 /**
  * A Pages-specific extractor context.
  */
 class PagesContext extends ContextBase {
-  private static final MessageActions PAGES_ACTIONS = new MessageActions(
-      ContextBase.COMMON_ACTIONS);
+  
+  private static final MessageActions PAGES_ACTIONS;
+  static {
+      PAGES_ACTIONS = new MessageActions(ContextBase.COMMON_ACTIONS);
+      PAGES_ACTIONS.setAction(10000, new ExtractTextActionBase<DocumentArchive>(DocumentArchive.PARSER) {
+    	  @Override
+          protected void onMessage(DocumentArchive message, ArchiveInfo ai, MessageInfo mi, ExtractTextIWAContext context) throws IOException {
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("FooterMargin", String.valueOf(message.getFooterMargin()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("HeaderMargin", String.valueOf(message.getHeaderMargin()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("PageHeight", String.valueOf(message.getPageHeight()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("PageWidth", String.valueOf(message.getPageWidth()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("PageScale", String.valueOf(message.getPageScale()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("RightMargin", String.valueOf(message.getRightMargin()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("TopMargin", String.valueOf(message.getTopMargin()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("BottomMargin", String.valueOf(message.getBottomMargin()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("CitationRecordsCount", String.valueOf(message.getCitationRecordsCount()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("Orientation", String.valueOf(message.getOrientation()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("PreventImageConversionOnOpenning", String.valueOf(message.getSuper().getSuper().getPreventImageConversionOnOpen()));
+              ((ExtractTextCallback)context.getTarget()).onMetaBlock("getNeedsMovieCompatibilityUpgrade", String.valueOf(message.getSuper().getNeedsMovieCompatibilityUpgrade()));
+          }
+      });
+  }
 
   protected PagesContext(String documentFilename, ExtractTextCallback target) {
     super(documentFilename, target);

--- a/iwana-extract/src/test/java/com/evernote/iwana/extract/TestExtractTextIWAParser.java
+++ b/iwana-extract/src/test/java/com/evernote/iwana/extract/TestExtractTextIWAParser.java
@@ -15,11 +15,15 @@
  */
 package com.evernote.iwana.extract;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
+import java.util.Map;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -80,6 +84,36 @@ public class TestExtractTextIWAParser {
     assertContains("A second page...", contents);
 
   }
+  
+  //Test meta data extraction.
+  
+  @Test
+  public void testPagesMetaData() throws Exception {
+      String[] args = new String[]{Paths.get(this.getClass().getResource("/test-documents/testPages2013.pages").toURI()).toString()};
+      ExtractTextApp extractTextApp1 = new ExtractTextApp();
+      Map<String, String> resultPages = extractTextApp1.parse(args);
+      assertTrue((resultPages.get("Content-Type")).contains("pages"));
+      assertEquals((resultPages.get("TopMargin")),("56.692917"));
+  }
+
+  @Test
+  public void testKeyMetaData() throws Exception {
+      String[] args = new String[]{Paths.get(this.getClass().getResource("/test-documents/testKeynote2013.key").toURI()).toString()};
+      ExtractTextApp extractTextApp = new ExtractTextApp();
+      Map<String, String> resultKey = extractTextApp.parse(args);
+      assertTrue((resultKey.get("Content-Type")).contains("key"));
+      assertEquals((resultKey.get("Comments")), "A nice comment; A nice comment");
+      
+  }
+  
+  @Test
+  public void testNumMetaData() throws Exception {
+      String[] args = new String[]{Paths.get(this.getClass().getResource("/test-documents/testNumbers2013.numbers").toURI()).toString()};
+      ExtractTextApp extractTextApp = new ExtractTextApp();
+      Map<String, String> resultNum = extractTextApp.parse(args);
+      assertTrue((resultNum.get("Content-Type")).contains("num"));
+      assertEquals((resultNum.get("NumberOfSheets")), "2");      
+  }
 
   private void assertContains(String needle, String haystack) {
     int i = haystack.indexOf(needle);
@@ -87,14 +121,14 @@ public class TestExtractTextIWAParser {
       fail("Couldn't find >" + needle + "< in >" + haystack+"<");
     }
   }
-
+  
   private String getText(String testFileName) throws Exception {
-    ExtractTextIWAParser parser = new ExtractTextIWAParser();
-    SimpleExtractTextCallback target = new SimpleExtractTextCallback();
-    File f = getTestFile(testFileName);
-    parser.parse(f, target);
-    return target.toString();
-  }
+	    ExtractTextIWAParser parser = new ExtractTextIWAParser();
+	    SimpleExtractTextCallback target = new SimpleExtractTextCallback();
+	    File f = getTestFile(testFileName);
+	    parser.parse(f, target, Paths.get(this.getClass().getResource("/test-documents/"+testFileName).toURI()).toString());
+	    return target.toString();
+	  }
 
   private File getTestFile(String testFileName) throws URISyntaxException {
     return Paths.get(
@@ -107,13 +141,18 @@ public class TestExtractTextIWAParser {
 
     @Override
     public void onTextBlock(String text, TextAttributes scope) {
-      sb.append(text);
-      sb.append("\n");
+      this.sb.append(text);
+      this.sb.append("\n");
     }
 
     @Override
     public String toString() {
       return sb.toString();
+    }
+    
+    @Override
+    public void onMetaBlock(String key, String value) {
+        this.sb.append("\n");
     }
 
   }


### PR DESCRIPTION
Read messages stream and use pyiwa message types information to compute type of file (pages/ numbers/ keynote). Build context properly and begin parse again enabling extraction of more relevant meta data.